### PR TITLE
Update `Template` argument name from `files` to `items`

### DIFF
--- a/Templates/custom_two/custom_two.swift
+++ b/Templates/custom_two/custom_two.swift
@@ -13,7 +13,7 @@ let templateTwo = Template(
         nameAttributeTwo,
         platformAttributeTwo
     ],
-    files: [
+    items: [
         .string(path: "\(nameAttributeTwo)/custom.swift", contents: testContentsTwo),
         .file(path: "\(nameAttributeTwo)/generated.swift", templatePath: "platform_two.stencil"),
     ]


### PR DESCRIPTION
This PR updates an  argument name in `Template` to match a change in tuist. This will allow the tuist test which uses this project to function once it has been fixed in [#3573](https://github.com/tuist/tuist/pull/3573).