### PR TITLE
Update `create-file` plugin to use the `PLUGIN_FILE_CONTENT` environment variable

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
         "state": {
           "branch": null,
           "revision": "54d7d05bbe4ea1666400999acefb0ebbc23e91d8",
-          "version": "3.8.0"
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/tuist/ProjectAutomation", .exact("3.8.0")),
+        .package(url: "https://github.com/tuist/ProjectAutomation", .revisionItem("54d7d05bbe4ea1666400999acefb0ebbc23e91d8")),
     ],
     targets: [
         .target(

--- a/Sources/CreateFile/main.swift
+++ b/Sources/CreateFile/main.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-try "File created with a plugin".write(
+let contentKey = "PLUGIN_FILE_CONTENT"
+guard let content = ProcessInfo.processInfo.environment[contentKey] else {
+    fatalError("Environment variable not found: '\(contentKey)'.")
+}
+try content.write(
     to: URL(fileURLWithPath: "plugin-file.txt"),
     atomically: true,
     encoding: .utf8


### PR DESCRIPTION
This PR update `create-file` plugin to use environment variable named `PLUGIN_FILE_CONTENT` to test https://github.com/tuist/tuist/pull/4611